### PR TITLE
Pin script dependencies

### DIFF
--- a/_scripts/requirements.txt
+++ b/_scripts/requirements.txt
@@ -1,3 +1,3 @@
-datasets
-numpy
-scikit-learn
+datasets==4.0.0
+numpy==2.3.2
+scikit-learn==1.7.1


### PR DESCRIPTION
## Summary
- pin `datasets`, `numpy`, and `scikit-learn` versions for script reproducibility

## Testing
- `black _scripts/build_json.py`
- `pip install -r _scripts/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb4eedb88325802bd51fb9e4f7be