### PR TITLE
Fix improperly quoted email link

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -38,7 +38,7 @@
             <p class="card-text text-center">{{ content | markdownify | remove: '<p>' | remove: '</p>' }}</p>
 
             <div aria-label="Basic example" class="btn-group d-flex" role="group">
-                <a aria-label=Email" class="btn btn-outline-dark" href="mailto:{{ site.email }}"
+                <a aria-label="Email" class="btn btn-outline-dark" href="mailto:{{ site.email }}"
                    style="border-bottom-left-radius: 0"><i class="fa fa-envelope"></i></a>
                 <a aria-label="LinkedIn" class="btn btn-outline-dark rounded-0"
                    href="https://www.linkedin.com/in/{{ site.linkedin }}"><i


### PR DESCRIPTION
## Summary
- Correct aria-label quoting on home page email button

## Testing
- `tidy -qe _layouts/home.html`

------
https://chatgpt.com/codex/tasks/task_e_68a9bb790c588325bc29bb59bb1e5c68