### PR TITLE
Improve serve script reliability

### DIFF
--- a/_scripts/serve.sh
+++ b/_scripts/serve.sh
@@ -1,3 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -euo pipefail
 
 bundle exec jekyll serve


### PR DESCRIPTION
## Summary
- harden serve script with bash safety flags
- standardize serve script formatting

## Testing
- `shellcheck _scripts/serve.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb81465c83259f8476b86689fe47