### PR TITLE
Improve publication cluster labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ with an interactive D3 publication map.
   [`ccm/publications`](https://huggingface.co/datasets/ccm/publications)
   Hugging Face dataset.
 - `_scripts/build_json.py` converts existing publication embeddings into the
-  two-dimensional map and labels clusters with class-based TF-IDF.
+  two-dimensional map and labels clusters with coverage-aware class-based
+  TF-IDF.
 - The separate
   [`scrape-my-publications`](https://github.com/cmccomb/scrape-my-publications)
   repository refreshes Scholar metadata and embeddings on the first day of

--- a/_scripts/build_json.py
+++ b/_scripts/build_json.py
@@ -16,6 +16,7 @@ import logging
 import os
 import platform
 import random
+import re
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -39,6 +40,8 @@ DEFAULT_DATASET_ID = "ccm/publications"
 DEFAULT_DATASET_REVISION = "main"
 DEFAULT_KMEANS_CLUSTERS = 12
 STOP_WORDS = ["of", "and", "selection"]
+MIN_LABEL_COVERAGE = 0.20
+MIN_LABEL_RECORDS = 2
 
 
 @dataclass(frozen=True)
@@ -247,10 +250,44 @@ def _cluster_id_series(labels: Sequence[int]) -> pandas.Series:
     )
 
 
+def _normalise_label_text(value: str) -> str:
+    """Normalise text so c-TF-IDF phrases can be matched across records."""
+
+    return " ".join(re.findall(r"[a-z0-9]+", value.lower()))
+
+
+def _phrase_document_coverage(phrase: str, records: pandas.DataFrame) -> int:
+    """Count records whose title or abstract contains a candidate phrase."""
+
+    normalised_phrase = _normalise_label_text(phrase)
+    if not normalised_phrase:
+        return 0
+
+    needle = f" {normalised_phrase} "
+    matching_records = 0
+    for bib_entry in records["bib_dict"]:
+        fragments = _bib_dict_to_fragments(bib_entry)
+        document = f" {_normalise_label_text(' '.join(fragments))} "
+        if needle in document:
+            matching_records += 1
+    return matching_records
+
+
+def _minimum_label_coverage(record_count: int) -> int:
+    """Return the minimum number of records that should support a label."""
+
+    if record_count <= 0:
+        return 0
+    return min(
+        record_count,
+        max(MIN_LABEL_RECORDS, int(numpy.ceil(record_count * MIN_LABEL_COVERAGE))),
+    )
+
+
 def ctfidf_labels(
-    citations: pandas.DataFrame, labels: Sequence[int], top_k: int = 3
+    citations: pandas.DataFrame, labels: Sequence[int]
 ) -> Dict[int, str]:
-    """Generate cluster labels using class-based TF-IDF."""
+    """Generate representative cluster labels using coverage-aware c-TF-IDF."""
 
     label_list = [int(label) for label in labels]
     df = citations.copy()
@@ -299,8 +336,16 @@ def ctfidf_labels(
         row = tfidf_matrix[index].toarray().ravel()
         if row.sum() == 0:
             continue
-        top_indices = row.argsort()[-top_k:][::-1]
-        labels_out[cluster_id] = vocabulary[top_indices][0]
+        cluster_records = df[df["cluster_id"] == cluster_id]
+        minimum_coverage = _minimum_label_coverage(len(cluster_records))
+        ranked_indices = row.argsort()[::-1]
+        for candidate_index in ranked_indices:
+            candidate = vocabulary[candidate_index]
+            if _phrase_document_coverage(candidate, cluster_records) >= minimum_coverage:
+                labels_out[cluster_id] = candidate
+                break
+        else:
+            labels_out[cluster_id] = vocabulary[ranked_indices[0]]
 
     return labels_out
 
@@ -546,7 +591,7 @@ def build_payload(
     citations["y"] = coordinates[:, 1]
     citations["cluster_id"] = _cluster_id_series(label_sequence)
 
-    ctfidf = ctfidf_labels(citations, label_sequence, top_k=2)
+    ctfidf = ctfidf_labels(citations, label_sequence)
     summaries = summarize_clusters(citations, label_sequence, ctfidf=ctfidf)
 
     records = citations[

--- a/assets/js/graph_layout.js
+++ b/assets/js/graph_layout.js
@@ -5,6 +5,9 @@
     const tooltip = d3.select(".tooltip");
     const legendContainer = d3.select(".colorbar-legend");
     const statusElement = document.getElementById("graph-status");
+    const legacyLabelCorrections = new Map([
+        ["face to face", "design teams"],
+    ]);
 
     function showGraphError(error) {
         console.error("Unable to render publication graph", error);
@@ -27,6 +30,11 @@
             return `${authors.join(", ")}, and ${lastAuthor}`;
         }
         return authors.join(" and ");
+    }
+
+    function displayClusterLabel(label) {
+        const value = String(label || "").trim();
+        return legacyLabelCorrections.get(value.toLowerCase()) || value;
     }
 
     d3.json("assets/json/pubs.json").then(rawPayload => {
@@ -251,7 +259,7 @@
                     return {
                         clusterId,
                         label: typeof summary?.label === "string" && summary.label
-                            ? summary.label
+                            ? displayClusterLabel(summary.label)
                             : `Cluster ${clusterId}`,
                         x: d3.mean(members, member => member.x) ?? 0,
                         y: d3.mean(members, member => member.y) ?? 0,

--- a/tests/test_build_json.py
+++ b/tests/test_build_json.py
@@ -170,10 +170,73 @@ def test_ctfidf_labels_produces_multiword_phrases() -> None:
     )
     labels = numpy.array([0, 0, 1, 1])
 
-    phrases = build_json.ctfidf_labels(citations, labels.tolist(), top_k=2)
+    phrases = build_json.ctfidf_labels(citations, labels.tolist())
 
     assert phrases[0].startswith("robot teamwork")
     assert "design automation" in phrases[1]
+
+
+def test_ctfidf_labels_prioritises_cluster_wide_phrases() -> None:
+    """A phrase from a few papers should not name a much broader cluster."""
+
+    citations = pandas.DataFrame(
+        [
+            {
+                "author_pub_id": "a1",
+                "bib_dict": {
+                    "title": "Virtual face-to-face collaboration",
+                    "abstract": "Face-to-face collaboration face-to-face collaboration.",
+                },
+            },
+            {
+                "author_pub_id": "a2",
+                "bib_dict": {
+                    "title": "Face-to-face team collaboration",
+                    "abstract": "Face-to-face collaboration face-to-face collaboration.",
+                },
+            },
+            {
+                "author_pub_id": "a3",
+                "bib_dict": {
+                    "title": "Design teams coordinate concepts",
+                    "abstract": "Design teams compare concepts.",
+                },
+            },
+            {
+                "author_pub_id": "a4",
+                "bib_dict": {
+                    "title": "Design teams select ideas",
+                    "abstract": "Design teams select concepts.",
+                },
+            },
+            {
+                "author_pub_id": "a5",
+                "bib_dict": {
+                    "title": "Design teams improve collaboration",
+                    "abstract": "Design teams study collaboration.",
+                },
+            },
+            {
+                "author_pub_id": "b1",
+                "bib_dict": {
+                    "title": "Manufacturing systems optimisation",
+                    "abstract": "Manufacturing systems improve production.",
+                },
+            },
+            {
+                "author_pub_id": "b2",
+                "bib_dict": {
+                    "title": "Manufacturing systems reliability",
+                    "abstract": "Manufacturing systems support production.",
+                },
+            },
+        ]
+    )
+    labels = numpy.array([0, 0, 0, 0, 0, 1, 1])
+
+    phrases = build_json.ctfidf_labels(citations, labels.tolist())
+
+    assert phrases[0] == "design teams"
 
 
 def test_summarize_clusters_uses_ctfidf_labels(


### PR DESCRIPTION
## What changed
- Select publication-cluster names using class-based TF-IDF **and** record coverage, so a phrase needs support from a meaningful share of the cluster.
- Correct the current legacy `face to face` display label to `design teams` while the refreshed generator takes effect.
- Document and test the coverage-aware behavior.

## Why
The prior scorer selected the highest c-TF-IDF phrase even when it described only two publications. In the current 19-publication cluster, `face to face` appears in 2 records while `design teams` appears in 7.

## Validation
- `pytest -q --ignore=_site` (13 passed)
- `node --check assets/js/graph_layout.js`
- `bundle exec jekyll build --strict_front_matter`
- Local rendered-graph check: `design teams` displayed with no browser errors.