### PR TITLE
Schedule publication refresh quarterly

### DIFF
--- a/.github/workflows/refresh-publication-graph.yml
+++ b/.github/workflows/refresh-publication-graph.yml
@@ -2,7 +2,7 @@ name: Refresh publication graph
 
 on:
   schedule:
-    - cron: "23 3 2 * *"
+    - cron: "23 3 2 1,4,7,10 *"
       timezone: America/New_York
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ with an interactive D3 publication map.
 - The separate
   [`scrape-my-publications`](https://github.com/cmccomb/scrape-my-publications)
   repository refreshes Scholar metadata and embeddings on the first day of
-  each month. This repository rebuilds and deploys the graph on the second day.
+  January, April, July, and October. This repository rebuilds and deploys the
+  graph on the following day.
 
 PyTorch and model downloads are not needed in this repository: the graph build
 uses embeddings already stored in the publication dataset.


### PR DESCRIPTION
## What changed
- Run the publication-graph rebuild at 3:23 AM Eastern on January 2, April 2, July 2, and October 2.
- Update the documented cadence to match the local Scholar collector's quarter-start schedule.

## Why
Quarterly updates reduce routine churn while preserving the existing incremental collection and validated deployment flow.

## Validation
- `actionlint .github/workflows/refresh-publication-graph.yml`
- `bundle exec jekyll build --strict_front_matter`