### PR TITLE
Improve accessibility, SEO, and deployment safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,13 @@ updates:
       timezone: America/New_York
       time: "06:23"
     open-pull-requests-limit: 5
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      timezone: America/New_York
+      time: "06:26"
+    open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -58,3 +59,38 @@ jobs:
         run: |
           node --check assets/js/graph_layout.js
           node --check assets/js/interface.js
+
+  browser:
+    name: Browser accessibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out tested revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          bundler-cache: true
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+      - name: Install browser test dependencies
+        run: npm ci
+      - name: Audit browser test dependencies
+        run: npm audit --audit-level=moderate
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run browser accessibility tests
+        run: npm run test:browser
+      - name: Upload browser failure report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     workflows: [CI]
     branches: [master]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,14 +17,18 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out the tested revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0

--- a/.github/workflows/refresh-publication-graph.yml
+++ b/.github/workflows/refresh-publication-graph.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: publication-graph-refresh
@@ -17,14 +15,17 @@ concurrency:
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
     steps:
-      - name: Check out the default branch
+      - name: Check out the trigger revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: master
-          persist-credentials: true
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -37,38 +38,114 @@ jobs:
         run: python _scripts/build_json.py --dataset ccm/publications --revision main --seed 42
       - name: Validate fresh publication snapshot
         run: python _scripts/validate_publications_json.py --max-age-days 1
-      - name: Record the refreshed snapshot
+      - name: Detect publication changes
+        id: changes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/json/pubs.json
-          if git diff --cached --quiet; then
-            exit 0
+          if git diff --quiet -- assets/json/pubs.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-          git commit -m "Refresh publication graph [skip ci]"
-          git push origin HEAD:master
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+      - name: Upload validated publication snapshot
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          bundler-cache: true
-      - name: Configure Pages
-        id: pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - name: Build site
-        run: bundle exec jekyll build --strict_front_matter --baseurl "${{ steps.pages.outputs.base_path }}"
-        env:
-          JEKYLL_ENV: production
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+          name: publication-graph-${{ github.run_id }}-${{ github.run_attempt }}
+          path: assets/json/pubs.json
+          if-no-files-found: error
+          retention-days: 7
 
-  deploy:
+  propose:
     needs: build
+    if: needs.build.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Check out the validated base revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Download validated publication snapshot
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: publication-graph-${{ github.run_id }}-${{ github.run_attempt }}
+          path: refresh-artifact
+      - name: Update the controlled automation branch
+        id: update
+        env:
+          AUTOMATION_BRANCH: automation/publication-graph-refresh
+        run: |
+          git fetch origin \
+            "+refs/heads/${AUTOMATION_BRANCH}:refs/remotes/origin/${AUTOMATION_BRANCH}" \
+            || true
+          git switch --create "$AUTOMATION_BRANCH"
+          cp refresh-artifact/pubs.json assets/json/pubs.json
+          git add assets/json/pubs.json
+
+          if git diff --cached --quiet; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Refresh publication graph"
+          git push --force-with-lease origin "HEAD:refs/heads/${AUTOMATION_BRANCH}"
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+          echo "branch=${AUTOMATION_BRANCH}" >> "$GITHUB_OUTPUT"
+      - name: Open or update the refresh pull request
+        if: steps.update.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTOMATION_BRANCH: ${{ steps.update.outputs.branch }}
+        run: |
+          pr_body="$RUNNER_TEMP/publication-refresh-pr.md"
+          {
+            echo "Automated quarterly publication graph refresh."
+            echo
+            echo "- Validated source run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Base branch: \`master\`"
+            echo "- Automation branch: \`${AUTOMATION_BRANCH}\`"
+            echo
+            echo "This pull request intentionally uses the normal CI and deployment path."
+          } > "$pr_body"
+
+          pr_number="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --base master \
+              --head "$AUTOMATION_BRANCH" \
+              --state open \
+              --json number \
+              --jq '.[0].number'
+          )"
+
+          if [[ -n "$pr_number" ]]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+              -f title="Refresh publication graph" \
+              -F body=@"$pr_body"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base master \
+              --head "$AUTOMATION_BRANCH" \
+              --title "Refresh publication graph" \
+              --body-file "$pr_body"
+          fi
+      - name: Dispatch CI for the automation branch
+        if: steps.update.outputs.updated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTOMATION_BRANCH: ${{ steps.update.outputs.branch }}
+        run: |
+          gh workflow run ci.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$AUTOMATION_BRANCH"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__/
 # Jekyll junk files
 _site
 .jekyll-cache
+
+# Node and Playwright outputs
+node_modules/
+test-results/
+playwright-report/

--- a/404.html
+++ b/404.html
@@ -1,4 +1,9 @@
 ---
 layout: nonexistent
+title: Page not found
+description: "The requested page could not be found."
+heading: "404: Page not found"
+permalink: /404.html
+noindex: true
 ---
-**Sorry about that! It looks like this content doesn't exist.**
+Sorry about that. The content you requested does not exist.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ with an interactive D3 publication map.
 - The separate
   [`scrape-my-publications`](https://github.com/cmccomb/scrape-my-publications)
   repository refreshes Scholar metadata and embeddings on the first day of
-  January, April, July, and October. This repository rebuilds and deploys the
-  graph on the following day.
+  January, April, July, and October. This repository rebuilds the graph on the
+  following day and opens or updates a pull request from the controlled
+  `automation/publication-graph-refresh` branch. Merging that pull request uses
+  the normal tested deployment path.
 
 PyTorch and model downloads are not needed in this repository: the graph build
 uses embeddings already stored in the publication dataset.
@@ -41,6 +43,14 @@ python -m pytest
 python _scripts/validate_publications_json.py
 ```
 
+Install the locked browser test dependencies and Chromium:
+
+```bash
+npm ci
+npx playwright install chromium
+npm run test:browser
+```
+
 Regenerate the graph from the current dataset:
 
 ```bash
@@ -53,12 +63,15 @@ Hugging Face commit SHA for provenance.
 
 ## Automation
 
-- `CI` runs the Jekyll build, Python tests, snapshot validation, and JavaScript
-  syntax checks with read-only permissions.
-- `Deploy site` publishes only the exact `master` revision that passed CI.
-- `Refresh publication graph` rebuilds the committed snapshot monthly,
-  validates it, records the update, and deploys it in the same trusted run.
-- Dependabot monitors Ruby, Python, and GitHub Actions dependencies.
+- `CI` runs the Jekyll build, Python tests, snapshot validation, JavaScript
+  syntax checks, and Playwright/axe browser accessibility tests with read-only
+  permissions.
+- `Deploy site` publishes only the exact `master` push revision that passed CI;
+  it has no manual deployment path.
+- `Refresh publication graph` runs quarterly with read-only build permissions,
+  validates the proposed snapshot, and passes it to a narrowly permissioned job
+  that updates a pull request. It never pushes to `master` or deploys.
+- Dependabot monitors Ruby, Python, npm, and GitHub Actions dependencies.
 
 All external Actions are pinned to immutable commit SHAs. The live page also
 uses a restrictive content security policy and renders publication metadata as

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,6 @@
 Please report suspected vulnerabilities privately through GitHub's security
 advisory interface rather than opening a public issue.
 
-The CI workflow audits both the locked Ruby dependencies and the installed
-Python environment on every change. Ruby, Python, and GitHub Actions updates
-are also monitored monthly by Dependabot.
+The CI workflow audits the locked Ruby, Python, and npm dependencies on every
+change. Ruby, Python, npm, and GitHub Actions updates are also monitored monthly
+by Dependabot.

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,36 @@
 title: "Chris McComb, Ph.D."
 description: "Research, publications, and professional profile for Chris McComb."
 url: "https://cmccomb.com"
+baseurl: ""
 timezone: "America/New_York"
+locale: "en_US"
 author: "Chris McComb, Ph.D."
+person_name: "Chris McComb"
+job_title: "Professor, Mechanical Engineering"
 affiliation: "<a href='https://meche.engineering.cmu.edu/directory/bios/mccomb-christopher.html'>Professor @ CMU</a>"
+organization:
+  name: "Carnegie Mellon University"
+  url: "https://www.cmu.edu/"
+cmu_profile: "https://meche.engineering.cmu.edu/directory/bios/mccomb-christopher.html"
 email: ccm@cmu.edu
 twitter: ccmccomb
 github: cmccomb
 linkedin: ccmcc
 google_scholar: 0P9w_S0AAAAJ
-headshot: 'assets/images/headshot_optimized_square.jpg'
+headshot: "/assets/images/headshot_optimized_square.jpg"
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE.md
+  - README.md
+  - SECURITY.md
+  - THIRD_PARTY_NOTICES.md
+  - comb.gemspec
+  - node_modules
+  - package-lock.json
+  - package.json
+  - playwright-report
+  - playwright.config.ts
+  - test-results
+  - tests

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -1,0 +1,70 @@
+{%- assign seo_title = site.title -%}
+{%- if page.title and page.title != site.title -%}
+  {%- assign seo_title = page.title | append: ' | ' | append: site.title -%}
+{%- endif -%}
+{%- assign seo_description = page.description | default: site.description -%}
+{%- assign seo_path = page.canonical_url | default: page.url | default: '/' -%}
+{%- assign seo_canonical_url = seo_path | absolute_url -%}
+{%- assign seo_image_url = site.headshot | absolute_url -%}
+{%- assign person_url = '/' | absolute_url -%}
+{%- assign person_email = site.email | prepend: 'mailto:' -%}
+{%- assign github_url = site.github | prepend: 'https://github.com/' -%}
+{%- assign linkedin_url = site.linkedin | prepend: 'https://www.linkedin.com/in/' -%}
+{%- assign scholar_url = site.google_scholar | prepend: 'https://scholar.google.com/citations?user=' -%}
+{%- assign twitter_url = site.twitter | prepend: 'https://x.com/' -%}
+<title>{{ seo_title | escape }}</title>
+<meta content="{{ seo_description | escape }}" name="description">
+<link href="{{ seo_canonical_url | escape }}" rel="canonical">
+{%- if page.noindex %}
+<meta content="noindex, nofollow" name="robots">
+{%- endif %}
+<meta content="{{ site.locale | default: 'en_US' | escape }}" property="og:locale">
+<meta content="{% if page.noindex %}website{% else %}profile{% endif %}" property="og:type">
+<meta content="{{ site.title | escape }}" property="og:site_name">
+<meta content="{{ seo_title | escape }}" property="og:title">
+<meta content="{{ seo_description | escape }}" property="og:description">
+<meta content="{{ seo_canonical_url | escape }}" property="og:url">
+<meta content="{{ seo_image_url | escape }}" property="og:image">
+<meta content="image/jpeg" property="og:image:type">
+<meta content="600" property="og:image:width">
+<meta content="600" property="og:image:height">
+<meta content="Headshot of {{ site.person_name | default: site.author | escape }}" property="og:image:alt">
+<meta content="summary" name="twitter:card">
+{%- if site.twitter %}
+<meta content="@{{ site.twitter | escape }}" name="twitter:site">
+<meta content="@{{ site.twitter | escape }}" name="twitter:creator">
+{%- endif %}
+<meta content="{{ seo_title | escape }}" name="twitter:title">
+<meta content="{{ seo_description | escape }}" name="twitter:description">
+<meta content="{{ seo_image_url | escape }}" name="twitter:image">
+<meta content="Headshot of {{ site.person_name | default: site.author | escape }}" name="twitter:image:alt">
+{%- unless page.noindex %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": {{ site.person_name | default: site.author | jsonify }},
+  "url": {{ person_url | jsonify }},
+  "image": {{ seo_image_url | jsonify }},
+  "email": {{ person_email | jsonify }},
+  "jobTitle": {{ site.job_title | jsonify }},
+  "worksFor": {
+    "@type": "CollegeOrUniversity",
+    "name": {{ site.organization.name | jsonify }},
+    "url": {{ site.organization.url | jsonify }}
+  },
+  "affiliation": {
+    "@type": "CollegeOrUniversity",
+    "name": {{ site.organization.name | jsonify }},
+    "url": {{ site.organization.url | jsonify }}
+  },
+  "sameAs": [
+    {{ github_url | jsonify }},
+    {{ linkedin_url | jsonify }},
+    {{ scholar_url | jsonify }},
+    {{ twitter_url | jsonify }},
+    {{ site.cmu_profile | jsonify }}
+  ]
+}
+</script>
+{%- endunless %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,8 +7,7 @@
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <meta content="no-referrer" name="referrer">
     <meta content="{{ site.author }}" name="author">
-    <meta content="Research, publications, and professional profile for {{ site.author }}." name="description">
-    <title>{{ site.title }}</title>
+    {% include seo.html %}
     <link href="{{ '/assets/images/favicon.svg' | relative_url }}" rel="icon" type="image/svg+xml">
     <link href="{{ '/assets/vendor/bootstrap/bootstrap.min.css' | relative_url }}" rel="stylesheet">
     <link href="{{ '/assets/css/default_style.css' | relative_url }}" rel="stylesheet">
@@ -16,23 +15,34 @@
     <script defer src="{{ '/assets/vendor/d3/d3.v7.9.0.min.js' | relative_url }}"></script>
     <script defer src="{{ '/assets/js/graph_layout.js' | relative_url }}"></script>
 </head>
-<body class="bg-dark d-flex flex-column h-100">
+<body class="bg-dark d-flex flex-column">
 
-<div class="container-fluid blur unselectable p-0" id="graph-container">
-    <svg id="publication-graph" role="img" aria-label="Interactive map of publications grouped by research topic"></svg>
-    <div class="tooltip"></div>
+<div aria-hidden="true" aria-label="Interactive publication map"
+     class="container-fluid blur unselectable p-0" id="graph-container" inert role="region">
+    <button class="btn btn-light graph-close" hidden id="graph-close" type="button">
+        <span aria-hidden="true">&larr;</span>
+        <span>Back to profile</span>
+    </button>
+    <svg aria-describedby="publication-graph-description" aria-labelledby="publication-graph-title"
+         id="publication-graph" role="group">
+        <title id="publication-graph-title">Interactive publication map</title>
+        <desc id="publication-graph-description">
+            Publications are grouped by research topic. Use Tab to enter the map and arrow keys to move between publications.
+        </desc>
+    </svg>
+    <div aria-hidden="true" class="tooltip" id="publication-tooltip" role="tooltip"></div>
     <div class="colorbar-legend" role="img" aria-label="Color legend for publication years"></div>
     <div class="graph-status" id="graph-status" role="status" aria-live="polite" hidden></div>
 </div>
 
-<div class="row h-100 justify-content-center align-items-center " id="profile">
+<main aria-hidden="false" class="profile-shell d-flex flex-grow-1 justify-content-center align-items-center"
+      id="profile">
     <div class="card px-0">
-        <!--        <button id="exit" type="button" class="btn-close" aria-label="Close"></button>-->
         <img alt="A headshot of {{ site.author }}" class="card-img-top"
-             src="{{ site.headshot | relative_url }}"/>
+             decoding="async" height="600" src="{{ site.headshot | relative_url }}" width="600">
         <div class="card-body">
-            <h5 class="card-title text-center">{{ site.author }}</h5>
-            <h6 class="card-subtitle mb-2 text-muted text-center"> {{ site.affiliation }} </h6>
+            <h1 class="card-title h5 text-center">{{ site.author }}</h1>
+            <p class="card-subtitle h6 mb-2 text-muted text-center"> {{ site.affiliation }} </p>
             <p class="card-text text-center">{{ content | markdownify | remove: '<p>' | remove: '</p>' }}</p>
 
             <div aria-label="Contact and profile links" class="btn-group d-flex" role="group">
@@ -48,19 +58,21 @@
                     <svg aria-hidden="true" class="icon" viewBox="0 0 512 512"><path d="M216.5 362.5c-66-8-112.5-55.5-112.5-117 0-25 9-52 24-70-6.5-16.5-5.5-51.5 2-66 20-2.5 47 8 63 22.5 19-6 39-9 63.5-9s44.5 3 62.5 8.5c15.5-14 43-24.5 63-22 7 13.5 8 48.5 1.5 65.5 16 19 24.5 44.5 24.5 70.5 0 61.5-46.5 108-113.5 116.5 17 11 28.5 35 28.5 62.5l0 52C323 491.5 335.5 500 350.5 494 441 459.5 512 369 512 257 512 115.5 397 0 255.5 0S0 115.5 0 257c0 111 70.5 203 165.5 237.5 13.5 5 26.5-4 26.5-17.5l0-40c-7 3-16 5-24 5-33 0-52.5-18-66.5-51.5-5.5-13.5-11.5-21.5-23-23-6-.5-8-3-8-6 0-6 10-10.5 20-10.5 14.5 0 27 9 40 27.5 10 14.5 20.5 21 33 21s20.5-4.5 32-16c8.5-8.5 15-16 21-21z"/></svg>
                 </a>
                 <a aria-label="Google Scholar" class="btn btn-outline-dark"
-                   href="https://scholar.google.com/citations?user={{ site.google_scholar }}">
+                   href="https://scholar.google.com/citations?user={{ site.google_scholar }}&amp;hl=en">
                     <svg aria-hidden="true" class="icon" viewBox="0 0 512 512"><path d="M390.9 298.5s0 .1 .1 .1c9.2 19.4 14.4 41.1 14.4 64-.1 82.5-66.9 149.4-149.4 149.4S106.7 445.1 106.7 362.7c0-22.9 5.2-44.6 14.4-64 1.7-3.6 3.6-7.2 5.6-10.7 4.4-7.6 9.4-14.7 15-21.3 27.4-32.6 68.5-53.3 114.4-53.3 33.6 0 64.6 11.1 89.6 29.9 9.1 6.9 17.4 14.7 24.8 23.5 5.6 6.6 10.6 13.8 15 21.3 2 3.4 3.8 7 5.5 10.5l-.1-.1zm26.4-18.8c-30.1-58.4-91-98.4-161.3-98.4s-131.2 40-161.3 98.4l-94.7-77 256-202.7 256 202.7-94.7 77.1 0-.1z"/></svg>
                 </a>
             </div>
-            <button class="btn btn-outline-dark w-100 rounded-0 rounded-bottom border-top-0 explore-button" id="exit">
-                <svg aria-hidden="true" class="icon" viewBox="0 0 16 16"><path d="M1.5 1A1.5 1.5 0 0 0 0 2.5v11A1.5 1.5 0 0 0 1.5 15h13a1.5 1.5 0 0 0 1.5-1.5v-11A1.5 1.5 0 0 0 14.5 1h-13ZM1 2.5a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-11Zm2.5 9.5a.5.5 0 0 0 .5-.5V9h2.5a.5.5 0 0 0 0-1H4V5.5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 .5.5Zm9-8a.5.5 0 0 0-.5.5V7H9.5a.5.5 0 0 0 0 1H12v2.5a.5.5 0 0 0 1 0v-6a.5.5 0 0 0-.5-.5Z"/></svg>
-                <span>Explore Publications</span>
-            </button>
+            <a aria-controls="graph-container" aria-expanded="false"
+               class="btn btn-outline-dark w-100 rounded-0 rounded-bottom border-top-0 explore-button"
+               href="https://scholar.google.com/citations?user={{ site.google_scholar }}&amp;hl=en" id="exit">
+                <span class="explore-label--graph">Explore publication map</span>
+                <span class="explore-label--scholar">View publications on Google Scholar</span>
+            </a>
         </div>
     </div>
-</div>
+</main>
 
-<footer class="footer mt-auto py-3" id="footer">
+<footer aria-hidden="false" class="footer mt-auto py-3" id="footer">
     <div class="container text-center">
         <span class="text-muted">&copy; {{ site.time | date: '%Y' }} {{ site.author | remove: ', Ph.D.' }}</span>
     </div>

--- a/_layouts/nonexistent.html
+++ b/_layouts/nonexistent.html
@@ -2,36 +2,32 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css"
-          integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" rel="stylesheet">
-    <link href="assets/css/default_style.css" rel="stylesheet">
-    <script crossorigin="anonymous" src="https://kit.fontawesome.com/c5e7391f02.js"></script>
-    <meta content='width=device-width, initial-scale=1.0' name='viewport'/>
-    <title>{{ site.title }}</title>
-
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-src 'none'; worker-src 'none'; manifest-src 'self'; upgrade-insecure-requests">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta content="no-referrer" name="referrer">
+    <meta content="{{ site.author | escape }}" name="author">
+    {% include seo.html %}
+    <link href="{{ '/assets/images/favicon.svg' | relative_url }}" rel="icon" type="image/svg+xml">
+    <link href="{{ '/assets/vendor/bootstrap/bootstrap.min.css' | relative_url }}" rel="stylesheet">
+    <link href="{{ '/assets/css/default_style.css' | relative_url }}" rel="stylesheet">
 </head>
-<body class="bg-dark d-flex flex-column h-100">
-
-<div class="row h-100 justify-content-center align-items-center " id="profile">
-    <div class="card px-0">
+<body class="bg-dark d-flex flex-column min-vh-100">
+<main class="container-fluid d-flex flex-grow-1 justify-content-center align-items-center" id="profile">
+    <section aria-labelledby="not-found-title" class="card px-0">
         <div class="card-body">
-            <p class="card-text text-center">{{ content | markdownify | remove: '<p>' | remove: '</p>' }}</p>
-
-            <a class="btn btn-outline-dark w-100" href="https://cmccomb.com" id="exit"
-               style="font-size: 0.9em;">
+            <h1 class="card-title h4 text-center" id="not-found-title">{{ page.heading | default: page.title | escape }}</h1>
+            <div class="card-text text-center">{{ content }}</div>
+            <a class="btn btn-outline-dark w-100" href="{{ '/' | relative_url }}" id="exit">
                 Take me home
             </a>
         </div>
-    </div>
-</div>
-
-
-
-<footer class="footer mt-auto py-3" id="footer" style="z-index:-100;">
+    </section>
+</main>
+<footer class="footer mt-auto py-3" id="footer">
     <div class="container text-center">
-        <span class="text-muted">&copy; <script>document.write(new Date().getFullYear())</script> {{ site.author | remove: ', Ph.D.' }}</span>
+        <span class="text-muted">&copy; {{ site.time | date: '%Y' }} {{ site.author | remove: ', Ph.D.' | escape }}</span>
     </div>
 </footer>
-
 </body>
 </html>

--- a/_scripts/requirements-dev.txt
+++ b/_scripts/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 pip-audit==2.10.1
-pytest==9.0.3
+pytest==9.1.1
 setuptools==83.0.0

--- a/_scripts/requirements.txt
+++ b/_scripts/requirements.txt
@@ -1,4 +1,4 @@
 datasets==5.0.0
 numpy==2.3.2
-pandas==2.3.2
-scikit-learn==1.7.1
+pandas==3.0.3
+scikit-learn==1.9.0

--- a/assets/css/default_style.css
+++ b/assets/css/default_style.css
@@ -1,12 +1,32 @@
-html, body {
+html {
+    min-height: 100%;
+}
+
+body {
     margin: 0;
-    height: 100%;
-    overflow: hidden;
+    min-height: 100vh;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+@supports (min-height: 100dvh) {
+    body {
+        min-height: 100dvh;
+    }
+}
+
+.profile-shell {
+    box-sizing: border-box;
+    min-height: calc(100vh - 3.5rem);
+    padding: 1.5rem 0.75rem;
+    position: relative;
+    width: 100%;
+    z-index: 1;
 }
 
 .card {
     flex-direction: column;
-    width: 70%;
+    width: min(90%, 300px);
     max-width: 300px;
 }
 
@@ -16,6 +36,7 @@ html, body {
 }
 
 .card img {
+    height: auto;
     width: 100%;
 }
 
@@ -53,6 +74,10 @@ html, body {
     display: none;
 }
 
+.explore-label--scholar {
+    display: none;
+}
+
 .explore-button::before {
     width: 1rem;
     height: 1rem;
@@ -63,7 +88,12 @@ html, body {
 }
 
 #footer {
-    z-index: -100;
+    position: relative;
+    z-index: 1;
+}
+
+#footer .text-muted {
+    color: #adb5bd !important;
 }
 
 p {
@@ -71,40 +101,64 @@ p {
 }
 
 #graph-container {
-    position: absolute;
-    top: 0;
-    right: 0;
+    position: fixed;
+    inset: 0;
     width: 100%;
-    height: 100%;
-    /*visibility: hidden;*/
+    height: 100vh;
+    overflow: hidden;
     pointer-events: none;
     user-select: none;
+    z-index: 0;
 }
 
 #graph-container.graph-active {
     pointer-events: auto;
+    z-index: 1000;
 }
 
 .blur {
-    -webkit-filter: blur(15px);
-    -moz-filter: blur(15px);
-    -o-filter: blur(15px);
-    -ms-filter: blur(15px);
     filter: blur(15px);
-    width: 100px;
-    height: 100px;
 }
 
-  @media (max-width: 768px) {
+@supports (height: 100dvh) {
+    #graph-container {
+        height: 100dvh;
+    }
+}
 
-      #graph-container {
-          visibility: hidden;
-      }
+.graph-close {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.45rem;
+    left: max(1rem, env(safe-area-inset-left));
+    position: absolute;
+    top: max(1rem, env(safe-area-inset-top));
+    z-index: 4;
+}
 
-      #graph-container.graph-active {
-          visibility: visible;
-      }
-  }
+.profile-shell[hidden],
+#footer[hidden],
+.graph-close[hidden] {
+    display: none !important;
+}
+
+@media (max-width: 768px) {
+    .explore-label--graph {
+        display: none;
+    }
+
+    .explore-label--scholar {
+        display: inline;
+    }
+
+    #graph-container {
+        visibility: hidden;
+    }
+
+    #graph-container.graph-active {
+        visibility: visible;
+    }
+}
 
 .vis-tooltip {
     width: 300px;
@@ -112,6 +166,6 @@ p {
     visibility: hidden;
 }
 
-#graph-container:focus {
-    outline: 0;
+#graph-container[aria-hidden="true"] {
+    pointer-events: none;
 }

--- a/assets/css/home_style.css
+++ b/assets/css/home_style.css
@@ -1,20 +1,42 @@
 
 #graph-container > svg {
     width: 100%;
-    height: 100vh;
+    height: 100%;
 }
 
 .tooltip {
-    position: absolute;
-    padding: 6px;
-    font-size: 12px;
-    background: rgba(255, 255, 255, 0.9);
+    position: fixed;
+    z-index: 5;
+    max-width: min(400px, calc(100vw - 1.5rem));
+    padding: 0.5rem 0.65rem;
+    color: #101214;
+    font-size: 0.8rem;
+    line-height: 1.35;
+    background: rgba(255, 255, 255, 0.96);
     border: 1px solid #444;
     border-radius: 4px;
     white-space: normal;
-    max-width: 400px;
     pointer-events: none;
     opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.publication-link {
+    cursor: pointer;
+    outline: none;
+}
+
+.publication-node {
+    transition: filter 120ms ease, stroke-width 120ms ease;
+    vector-effect: non-scaling-stroke;
+}
+
+.publication-link:hover .publication-node,
+.publication-link:focus .publication-node,
+.publication-link:focus-visible .publication-node {
+    filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.95));
+    stroke: #fff;
+    stroke-width: 3px;
 }
 
 .graph-status {
@@ -70,4 +92,20 @@
     font-weight: 600;
     fill: #101214;
     letter-spacing: 0.02em;
+}
+
+@media (max-width: 768px) {
+    .colorbar-legend {
+        top: 4.5rem;
+        right: 0.75rem;
+        transform: scale(0.85);
+        transform-origin: top right;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .publication-node,
+    .tooltip {
+        transition: none;
+    }
 }

--- a/assets/js/graph_layout.js
+++ b/assets/js/graph_layout.js
@@ -5,6 +5,7 @@
     const tooltip = d3.select(".tooltip");
     const legendContainer = d3.select(".colorbar-legend");
     const statusElement = document.getElementById("graph-status");
+    const graphContainer = document.getElementById("graph-container");
     const legacyLabelCorrections = new Map([
         ["face to face", "design teams"],
     ]);
@@ -169,31 +170,148 @@
             r: 0,
         }));
 
-        const nodeSelection = svg.selectAll("rect.publication-node")
+        const publicationLinks = svg.selectAll("a.publication-link")
             .data(nodes)
             .enter()
-            .append("rect")
+            .append("a")
+            .attr("class", "publication-link")
+            .attr("href", node => node.link)
+            .attr("target", "_blank")
+            .attr("rel", "noopener noreferrer")
+            .attr("tabindex", -1)
+            .attr("aria-describedby", "publication-tooltip")
+            .attr("aria-label", node => (
+                `${node.title}; ${node.num_citations} citation${node.num_citations === 1 ? "" : "s"}`
+            ));
+        const nodeSelection = publicationLinks.append("rect")
             .attr("class", "publication-node")
             .attr("fill", node => node.color)
-            .attr("opacity", 1)
-            .attr("role", "link")
-            .attr("aria-label", node => `${node.title}; ${node.num_citations} citations`)
-            .on("mouseover", (event, node) => {
-                event.currentTarget.style.cursor = "pointer";
-                const tooltipText = [
-                    formatAuthors(node.author),
-                    `“${node.title}.”`,
-                    node.citation,
-                ].filter(Boolean).join(" ");
-                tooltip.text(tooltipText)
-                    .style("opacity", 1)
-                    .style("left", `${event.pageX + 10}px`)
-                    .style("top", `${event.pageY + 10}px`);
+            .attr("opacity", 1);
+        const publicationLinkNodes = publicationLinks.nodes();
+        let activePublicationIndex = 0;
+
+        function graphIsActive() {
+            return graphContainer?.classList.contains("graph-active") ?? false;
+        }
+
+        function setRovingIndex(index, shouldFocus = false) {
+            const boundedIndex = Math.max(0, Math.min(publicationLinkNodes.length - 1, index));
+            activePublicationIndex = boundedIndex;
+            publicationLinks.attr("tabindex", (_node, linkIndex) => (
+                graphIsActive() && linkIndex === activePublicationIndex ? 0 : -1
+            ));
+
+            if (shouldFocus) {
+                publicationLinkNodes[activePublicationIndex]?.focus({ preventScroll: true });
+            }
+        }
+
+        function getTooltipText(node) {
+            return [
+                formatAuthors(node.author),
+                `“${node.title}.”`,
+                node.citation,
+            ].filter(Boolean).join(" ");
+        }
+
+        function positionTooltip(clientX, clientY) {
+            const tooltipNode = tooltip.node();
+            if (!tooltipNode) {
+                return;
+            }
+
+            const margin = 12;
+            const offset = 12;
+            const maxLeft = Math.max(margin, window.innerWidth - tooltipNode.offsetWidth - margin);
+            const maxTop = Math.max(margin, window.innerHeight - tooltipNode.offsetHeight - margin);
+            const preferredTop = clientY + offset + tooltipNode.offsetHeight <= window.innerHeight - margin
+                ? clientY + offset
+                : clientY - tooltipNode.offsetHeight - offset;
+
+            tooltip
+                .style("left", `${Math.max(margin, Math.min(clientX + offset, maxLeft))}px`)
+                .style("top", `${Math.max(margin, Math.min(preferredTop, maxTop))}px`);
+        }
+
+        function showPointerTooltip(event, node) {
+            tooltip
+                .text(getTooltipText(node))
+                .attr("aria-hidden", "false")
+                .style("opacity", 1);
+            positionTooltip(event.clientX, event.clientY);
+        }
+
+        function showFocusTooltip(event, node) {
+            const target = event.currentTarget.querySelector(".publication-node")
+                || event.currentTarget;
+            const bounds = target.getBoundingClientRect();
+            tooltip
+                .text(getTooltipText(node))
+                .attr("aria-hidden", "false")
+                .style("opacity", 1);
+            positionTooltip(
+                bounds.left + bounds.width / 2,
+                bounds.top + bounds.height / 2
+            );
+        }
+
+        function hideTooltip() {
+            tooltip
+                .attr("aria-hidden", "true")
+                .style("opacity", 0);
+        }
+
+        publicationLinks
+            .on("mouseenter", showPointerTooltip)
+            .on("mousemove", showPointerTooltip)
+            .on("mouseleave", event => {
+                if (document.activeElement !== event.currentTarget) {
+                    hideTooltip();
+                }
             })
-            .on("mouseout", () => tooltip.style("opacity", 0))
-            .on("click", (_event, node) => {
-                window.open(node.link, "_blank", "noopener,noreferrer");
+            .on("focus", function handlePublicationFocus(event, node) {
+                activePublicationIndex = publicationLinkNodes.indexOf(this);
+                setRovingIndex(activePublicationIndex);
+                showFocusTooltip(event, node);
+            })
+            .on("blur", hideTooltip)
+            .on("keydown", event => {
+                let nextIndex;
+                switch (event.key) {
+                    case "ArrowRight":
+                    case "ArrowDown":
+                        nextIndex = (activePublicationIndex + 1) % publicationLinkNodes.length;
+                        break;
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                        nextIndex = (
+                            activePublicationIndex - 1 + publicationLinkNodes.length
+                        ) % publicationLinkNodes.length;
+                        break;
+                    case "Home":
+                        nextIndex = 0;
+                        break;
+                    case "End":
+                        nextIndex = publicationLinkNodes.length - 1;
+                        break;
+                    default:
+                        return;
+                }
+
+                event.preventDefault();
+                setRovingIndex(nextIndex, true);
             });
+
+        setRovingIndex(activePublicationIndex);
+        graphContainer?.addEventListener("publicationgraph:visibilitychange", event => {
+            if (event.detail?.isVisible) {
+                setRovingIndex(activePublicationIndex);
+                return;
+            }
+
+            publicationLinks.attr("tabindex", -1);
+            hideTooltip();
+        });
 
         const clusterLabelLayer = svg.append("g")
             .attr("class", "cluster-label-layer")

--- a/assets/js/interface.js
+++ b/assets/js/interface.js
@@ -2,20 +2,78 @@
     "use strict";
 
     const exploreButton = document.getElementById("exit");
-    if (!exploreButton) {
+    const graphContainer = document.getElementById("graph-container");
+    const graphCloseButton = document.getElementById("graph-close");
+    const profile = document.getElementById("profile");
+    const footer = document.getElementById("footer");
+    const mobileQuery = window.matchMedia("(max-width: 768px)");
+
+    if (
+        !exploreButton
+        || !graphContainer
+        || !graphCloseButton
+        || !profile
+        || !footer
+    ) {
         return;
     }
 
-    exploreButton.addEventListener("click", () => {
-        if (window.matchMedia("(max-width: 768px)").matches) {
-            window.location.assign("https://scholar.google.com/citations?user=0P9w_S0AAAAJ&hl=en");
+    function setRegionVisibility(element, isVisible) {
+        element.hidden = !isVisible;
+        element.setAttribute("aria-hidden", String(!isVisible));
+    }
+
+    function announceGraphVisibility(isVisible) {
+        graphContainer.dispatchEvent(new CustomEvent("publicationgraph:visibilitychange", {
+            detail: { isVisible },
+        }));
+    }
+
+    function openGraph(event) {
+        const isPlainPrimaryClick = (
+            event.button === 0
+            && !event.altKey
+            && !event.ctrlKey
+            && !event.metaKey
+            && !event.shiftKey
+        );
+
+        if (mobileQuery.matches || !isPlainPrimaryClick) {
             return;
         }
 
-        document.getElementById("profile")?.remove();
-        document.getElementById("footer")?.remove();
-        const graphContainer = document.getElementById("graph-container");
-        graphContainer?.classList.remove("blur");
-        graphContainer?.classList.add("graph-active");
+        event.preventDefault();
+        setRegionVisibility(profile, false);
+        setRegionVisibility(footer, false);
+        graphContainer.inert = false;
+        graphContainer.setAttribute("aria-hidden", "false");
+        graphContainer.classList.remove("blur");
+        graphContainer.classList.add("graph-active");
+        graphCloseButton.hidden = false;
+        exploreButton.setAttribute("aria-expanded", "true");
+        announceGraphVisibility(true);
+        graphCloseButton.focus({ preventScroll: true });
+    }
+
+    function closeGraph() {
+        graphCloseButton.hidden = true;
+        graphContainer.classList.remove("graph-active");
+        graphContainer.classList.add("blur");
+        graphContainer.setAttribute("aria-hidden", "true");
+        graphContainer.inert = true;
+        setRegionVisibility(profile, true);
+        setRegionVisibility(footer, true);
+        exploreButton.setAttribute("aria-expanded", "false");
+        announceGraphVisibility(false);
+        exploreButton.focus({ preventScroll: true });
+    }
+
+    exploreButton.addEventListener("click", openGraph);
+    graphCloseButton.addEventListener("click", closeGraph);
+    graphContainer.addEventListener("keydown", event => {
+        if (event.key === "Escape" && graphContainer.classList.contains("graph-active")) {
+            event.preventDefault();
+            closeGraph();
+        }
     });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "cmccomb-site-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cmccomb-site-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "4.12.1",
+        "@playwright/test": "1.61.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cmccomb-site-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "npm run test:browser",
+    "test:browser": "playwright test",
+    "test:browser:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
+    "@playwright/test": "1.61.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  outputDir: "test-results",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [
+        ["line"],
+        ["html", { open: "never" }],
+      ]
+    : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command:
+      "JEKYLL_ENV=production bundle exec jekyll build --strict_front_matter --disable-disk-cache && exec bundle exec jekyll serve --skip-initial-build --no-watch --disable-disk-cache --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+---
+layout: null
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ '/sitemap.xml' | absolute_url }}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,10 @@
+---
+layout: null
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>{{ '/' | absolute_url | xml_escape }}</loc>
+  </url>
+</urlset>

--- a/tests/browser/site.spec.ts
+++ b/tests/browser/site.spec.ts
@@ -1,0 +1,284 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+
+const SITE_ORIGIN = "https://cmccomb.com";
+const TEST_ORIGIN = "http://127.0.0.1:4173";
+const SCHOLAR_URL_PATTERN = /^https:\/\/scholar\.google\.com\/citations\?/;
+const HEADSHOT_URL = `${SITE_ORIGIN}/assets/images/headshot_optimized_square.jpg`;
+const CMU_PROFILE_URL =
+  "https://meche.engineering.cmu.edu/directory/bios/mccomb-christopher.html";
+
+async function expectNoAccessibilityViolations(page: Page): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+
+  expect(
+    results.violations,
+    results.violations
+      .map((violation) => `${violation.id}: ${violation.help}`)
+      .join("\n"),
+  ).toEqual([]);
+}
+
+test.describe("homepage", () => {
+  test("has semantic metadata and no initial accessibility violations", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("main")).toHaveCount(1);
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Chris McComb, Ph.D.",
+      }),
+    ).toBeVisible();
+
+    const description = page.locator('meta[name="description"]');
+    await expect(description).toHaveAttribute("content", /professional profile/i);
+    await expect(description).not.toHaveAttribute("content", /\.\.$/);
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      `${SITE_ORIGIN}/`,
+    );
+
+    await expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+      "content",
+      "profile",
+    );
+    await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+      "content",
+      `${SITE_ORIGIN}/`,
+    );
+    await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+      "content",
+      HEADSHOT_URL,
+    );
+    await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+      "content",
+      "summary",
+    );
+    await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute(
+      "content",
+      HEADSHOT_URL,
+    );
+
+    const structuredData = page.locator('script[type="application/ld+json"]');
+    await expect(structuredData).toHaveCount(1);
+    const person = JSON.parse((await structuredData.textContent()) ?? "{}");
+    expect(person).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Person",
+      name: "Chris McComb",
+      url: `${SITE_ORIGIN}/`,
+      image: HEADSHOT_URL,
+      email: "mailto:ccm@cmu.edu",
+      jobTitle: "Professor, Mechanical Engineering",
+      worksFor: {
+        "@type": "CollegeOrUniversity",
+        name: "Carnegie Mellon University",
+        url: "https://www.cmu.edu/",
+      },
+      affiliation: {
+        "@type": "CollegeOrUniversity",
+        name: "Carnegie Mellon University",
+        url: "https://www.cmu.edu/",
+      },
+    });
+    expect(person.sameAs).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^https:\/\/github\.com\//),
+        expect.stringMatching(/^https:\/\/www\.linkedin\.com\//),
+        expect.stringMatching(SCHOLAR_URL_PATTERN),
+        "https://x.com/ccmccomb",
+        CMU_PROFILE_URL,
+      ]),
+    );
+
+    const graph = page.locator("#graph-container");
+    await expect(graph).toHaveAttribute("aria-hidden", "true");
+    await expect(graph).toHaveAttribute("inert", "");
+
+    await expectNoAccessibilityViolations(page);
+  });
+
+  test("keeps controls reachable without horizontal overflow in short landscape", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 667, height: 320 });
+    await page.goto("/");
+
+    const publicationControl = page.locator("#exit");
+    await expect(publicationControl).toBeVisible();
+    await publicationControl.scrollIntoViewIfNeeded();
+    await publicationControl.focus();
+    await expect(publicationControl).toBeFocused();
+
+    const controlBox = await publicationControl.boundingBox();
+    expect(controlBox).not.toBeNull();
+    expect(controlBox?.y).toBeGreaterThanOrEqual(0);
+    expect((controlBox?.y ?? 0) + (controlBox?.height ?? 0)).toBeLessThanOrEqual(
+      320,
+    );
+
+    const dimensions = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+  });
+
+  test("activates the graph, supports native keyboard links, and restores focus", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+
+    const graph = page.locator("#graph-container");
+    const explore = page.locator("#exit");
+    const close = page.locator("#graph-close");
+
+    await expect(explore).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("a.publication-link")).not.toHaveCount(0);
+
+    await explore.click();
+    await expect(graph).toHaveAttribute("aria-hidden", "false");
+    await expect(graph).not.toHaveAttribute("inert", "");
+    await expect(explore).toHaveAttribute("aria-expanded", "true");
+    await expect(close).toBeVisible();
+    await expect(close).toBeFocused();
+    await expectNoAccessibilityViolations(page);
+
+    const firstPublication = page.locator("a.publication-link").first();
+    const secondPublication = page.locator("a.publication-link").nth(1);
+    await expect(firstPublication).toHaveAttribute("tabindex", "0");
+    await expect(secondPublication).toHaveAttribute("tabindex", "-1");
+    await firstPublication.focus();
+    await expect(firstPublication).toBeFocused();
+
+    await firstPublication.press("ArrowRight");
+    await expect(secondPublication).toBeFocused();
+    await expect(secondPublication).toHaveAttribute(
+      "href",
+      SCHOLAR_URL_PATTERN,
+    );
+
+    await page.context().route("https://scholar.google.com/**", async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: "<title>Google Scholar</title>",
+      });
+    });
+    const popupPromise = page.waitForEvent("popup");
+    await secondPublication.press("Enter");
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(SCHOLAR_URL_PATTERN);
+    await popup.close();
+
+    await close.click();
+    await expect(graph).toHaveAttribute("aria-hidden", "true");
+    await expect(graph).toHaveAttribute("inert", "");
+    await expect(explore).toHaveAttribute("aria-expanded", "false");
+    await expect(explore).toBeFocused();
+
+    await explore.click();
+    await expect(close).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(graph).toHaveAttribute("aria-hidden", "true");
+    await expect(explore).toBeFocused();
+  });
+
+  test("uses the explicit Google Scholar fallback on mobile", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+
+    const explore = page.locator("#exit");
+    await expect(explore).toHaveAttribute("href", SCHOLAR_URL_PATTERN);
+    await expect(explore.locator(".explore-label--scholar")).toBeVisible();
+    await expect(explore.locator(".explore-label--graph")).toBeHidden();
+
+    await page.route("https://scholar.google.com/**", async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: "<title>Google Scholar</title>",
+      });
+    });
+    await explore.click();
+    await expect(page).toHaveURL(SCHOLAR_URL_PATTERN);
+  });
+});
+
+test.describe("custom 404", () => {
+  test("serves nested paths with semantic, self-hosted assets", async ({
+    page,
+  }) => {
+    const externalResourceUrls: string[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (
+        request.resourceType() !== "document" &&
+        url.origin !== TEST_ORIGIN
+      ) {
+        externalResourceUrls.push(request.url());
+      }
+    });
+
+    const response = await page.goto("/missing/nested/publication");
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "404: Page not found" }),
+    ).toBeVisible();
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      "content",
+      "noindex, nofollow",
+    );
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      `${SITE_ORIGIN}/404.html`,
+    );
+
+    const stylesheetUrls = await page
+      .locator('link[rel="stylesheet"]')
+      .evaluateAll((links) => links.map((link) => (link as HTMLLinkElement).href));
+    expect(stylesheetUrls).toEqual(
+      expect.arrayContaining([
+        `${TEST_ORIGIN}/assets/vendor/bootstrap/bootstrap.min.css`,
+        `${TEST_ORIGIN}/assets/css/default_style.css`,
+      ]),
+    );
+    expect(stylesheetUrls.every((url) => url.startsWith(`${TEST_ORIGIN}/`))).toBe(
+      true,
+    );
+    await expect(page.locator("script")).toHaveCount(0);
+    expect(externalResourceUrls).toEqual([]);
+
+    const homeLink = page.getByRole("link", { name: /take me home/i });
+    await expect(homeLink).toHaveAttribute("href", "/");
+    await expectNoAccessibilityViolations(page);
+  });
+});
+
+test("publishes discovery files without development artifacts", async ({
+  request,
+}) => {
+  const robots = await request.get("/robots.txt");
+  expect(robots.status()).toBe(200);
+  expect(await robots.text()).toContain(
+    `Sitemap: ${SITE_ORIGIN}/sitemap.xml`,
+  );
+
+  const sitemap = await request.get("/sitemap.xml");
+  expect(sitemap.status()).toBe(200);
+  expect(await sitemap.text()).toContain(`<loc>${SITE_ORIGIN}/</loc>`);
+
+  for (const path of [
+    "/package.json",
+    "/playwright.config.ts",
+    "/tests/browser/site.spec.ts",
+  ]) {
+    expect((await request.get(path)).status()).toBe(404);
+  }
+});


### PR DESCRIPTION
## What changed

- make the homepage scroll correctly in short and landscape viewports
- add semantic `main`/`h1` structure, intrinsic image dimensions, and a real mobile Google Scholar fallback
- make publication nodes native SVG links with roving keyboard focus, arrow-key navigation, focus tooltips, and reversible graph activation
- add canonical, Open Graph, Twitter, and Person JSON-LD metadata plus `robots.txt` and `sitemap.xml`
- rebuild the custom 404 with self-hosted assets, nested-safe URLs, CSP, and no JavaScript
- deploy only the exact successful `master` CI SHA
- replace direct publication-refresh pushes/deploys with a controlled automation-branch PR and explicit CI dispatch
- add Playwright/axe browser coverage, npm auditing/Dependabot, and compatible Python dependency updates
- exclude development and test artifacts from the generated Pages site

## Why

The live page could clip controls in short viewports, the publication graph was not keyboard-operable or reversible, discovery metadata was incomplete, the nested 404 depended on external assets, and the refresh/deploy path could bypass the normal reviewed CI route.

## Impact

The visual identity is preserved while the profile and publication map become responsive and accessible. Search/social previews receive consistent metadata, missing pages are self-contained, and GitHub Pages only deploys revisions that passed the normal CI pipeline.

## Validation

- 13/13 Python tests
- 6/6 Playwright browser tests, including axe WCAG A/AA scans
- strict Jekyll build and `jekyll doctor`
- Actionlint and JavaScript syntax checks
- sitemap XML validation
- npm and pip audits: no known vulnerabilities
- desktop, mobile, short-landscape, graph, and nested-404 visual checks